### PR TITLE
Update to allow Vite 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-hmr-public-copy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Vite public to keep publicDir files synced during HMR",
   "type": "module",
   "main": "dist/index.cjs",
@@ -26,7 +26,7 @@
   "license": "MIT",
   "homepage": "https://github.com/davidwebca/vite-plugin-hmr-public-copy",
   "peerDependencies": {
-    "vite": "^3.0.0 || ^4.0.0"
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "esbuild": "^0.16.2"


### PR DESCRIPTION
- https://github.com/davidwebca/vite-plugin-hmr-public-copy/issues/1

Update package.json to allow installation with Vite 5